### PR TITLE
Add workaround for parameterized FPGA example

### DIFF
--- a/examples/fpga/turbulent/fpga_flow.py
+++ b/examples/fpga/turbulent/fpga_flow.py
@@ -138,6 +138,7 @@ def run(cfg: PhysicsNeMoConfig) -> None:
         criteria=Eq(x, channel_origin[0]),
         lambda_weighting={"u": 1.0, "v": 1.0, "w": 1.0},
         batch_per_epoch=5000,
+        parameterization=param_ranges
     )
     flow_domain.add_constraint(constraint_inlet, "inlet")
 
@@ -149,6 +150,7 @@ def run(cfg: PhysicsNeMoConfig) -> None:
         batch_size=cfg.batch_size.outlet,
         criteria=Eq(x, channel_origin[0] + channel_dim[0]),
         batch_per_epoch=5000,
+        parameterization=param_ranges
     )
     flow_domain.add_constraint(constraint_outlet, "outlet")
 
@@ -159,6 +161,7 @@ def run(cfg: PhysicsNeMoConfig) -> None:
         outvar={"u": 0, "v": 0, "w": 0},
         batch_size=cfg.batch_size.no_slip,
         batch_per_epoch=5000,
+        parameterization=param_ranges
     )
     flow_domain.add_constraint(no_slip, "no_slip")
 
@@ -177,6 +180,7 @@ def run(cfg: PhysicsNeMoConfig) -> None:
             "momentum_z": Symbol("sdf"),
         },
         batch_per_epoch=5000,
+        parameterization=param_ranges
     )
     flow_domain.add_constraint(lr_interior, "lr_interior")
 
@@ -197,6 +201,7 @@ def run(cfg: PhysicsNeMoConfig) -> None:
             "momentum_z": Symbol("sdf"),
         },
         batch_per_epoch=5000,
+        parameterization=param_ranges
     )
     flow_domain.add_constraint(hr_interior, "hr_interior")
 

--- a/examples/fpga/turbulent/fpga_flow.py
+++ b/examples/fpga/turbulent/fpga_flow.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from fpga_geometry import *
 
 import os
@@ -138,7 +139,7 @@ def run(cfg: PhysicsNeMoConfig) -> None:
         criteria=Eq(x, channel_origin[0]),
         lambda_weighting={"u": 1.0, "v": 1.0, "w": 1.0},
         batch_per_epoch=5000,
-        parameterization=param_ranges
+        parameterization=param_ranges,
     )
     flow_domain.add_constraint(constraint_inlet, "inlet")
 
@@ -150,7 +151,7 @@ def run(cfg: PhysicsNeMoConfig) -> None:
         batch_size=cfg.batch_size.outlet,
         criteria=Eq(x, channel_origin[0] + channel_dim[0]),
         batch_per_epoch=5000,
-        parameterization=param_ranges
+        parameterization=param_ranges,
     )
     flow_domain.add_constraint(constraint_outlet, "outlet")
 
@@ -161,7 +162,7 @@ def run(cfg: PhysicsNeMoConfig) -> None:
         outvar={"u": 0, "v": 0, "w": 0},
         batch_size=cfg.batch_size.no_slip,
         batch_per_epoch=5000,
-        parameterization=param_ranges
+        parameterization=param_ranges,
     )
     flow_domain.add_constraint(no_slip, "no_slip")
 
@@ -180,7 +181,7 @@ def run(cfg: PhysicsNeMoConfig) -> None:
             "momentum_z": Symbol("sdf"),
         },
         batch_per_epoch=5000,
-        parameterization=param_ranges
+        parameterization=param_ranges,
     )
     flow_domain.add_constraint(lr_interior, "lr_interior")
 
@@ -201,7 +202,7 @@ def run(cfg: PhysicsNeMoConfig) -> None:
             "momentum_z": Symbol("sdf"),
         },
         batch_per_epoch=5000,
-        parameterization=param_ranges
+        parameterization=param_ranges,
     )
     flow_domain.add_constraint(hr_interior, "hr_interior")
 

--- a/examples/fpga/turbulent/fpga_geometry.py
+++ b/examples/fpga/turbulent/fpga_geometry.py
@@ -26,13 +26,21 @@ with open("./conf/config.yaml", "r") as file:
     yaml_data = yaml.safe_load(file)
 parameterized = yaml_data["custom"]["parameterized"]
 
+HS_height_range = (0.40625, 0.8625)
+HS_length_range = (0.35, 0.65)
+
 if parameterized:
     # geometry parameterization
     HS_height = Symbol("HS_height")
     HS_length = Symbol("HS_length")
+    param_ranges = {HS_height: HS_height_range, HS_length: HS_length_range}
+    pr = Parameterization(param_ranges)
 else:
     HS_length = 0.65
     HS_height = 0.8625
+    fixed_param_ranges = {}
+    pr = Parameterization(fixed_param_ranges)
+
 
 # geometry params for domain
 channel_origin = (-2.5, -0.5, -0.5625)
@@ -59,6 +67,7 @@ channel = Channel(
         channel_origin[1] + channel_dim[1],
         channel_origin[2] + channel_dim[2],
     ),
+    parameterization=pr,
 )
 
 # fpga heat sink
@@ -69,27 +78,48 @@ heat_sink_base = Box(
         heat_sink_base_origin[1] + heat_sink_base_dim[1],
         heat_sink_base_origin[2] + heat_sink_base_dim[2],
     ),
+    parameterization=pr,
 )
 fin_center = (
     fin_origin[0] + fin_dim[0] / 2,
     fin_origin[1] + fin_dim[1] / 2,
     fin_origin[2] + fin_dim[2] / 2,
 )
-fin = Box(
-    fin_origin,
-    (
-        fin_origin[0] + fin_dim[0],
-        fin_origin[1] + fin_dim[1],
-        fin_origin[2] + fin_dim[2],
-    ),
-)
+# fin = Box(
+#     fin_origin,
+#     (
+#         fin_origin[0] + fin_dim[0],
+#         fin_origin[1] + fin_dim[1],
+#         fin_origin[2] + fin_dim[2],
+#     ),
+#     parameterization=pr,
+# )
 gap = (heat_sink_base_dim[2] - fin_dim[2]) / (total_fins - 1)  # gap between fins
-fin = fin.repeat(
-    gap,
-    repeat_lower=(0, 0, 0),
-    repeat_higher=(0, 0, total_fins - 1),
-    center=fin_center,
-)
+# fin = 0.
+for i in range(total_fins):
+    if i == 0:
+        fin = Box(
+            fin_origin,
+            (
+                fin_origin[0] + fin_dim[0],
+                fin_origin[1] + fin_dim[1],
+                fin_origin[2] + fin_dim[2],
+            ),
+            parameterization=pr,
+        )
+    else:
+        fin += Box(
+            (fin_origin[0], fin_origin[1], fin_origin[2] + i * gap),
+            (fin_origin[0] + fin_dim[0], fin_origin[1] + fin_dim[1], fin_origin[2] + i * gap + fin_dim[2]),
+            parameterization=pr,
+        )
+
+# fin = fin.repeat(
+#     gap,
+#     repeat_lower=(0, 0, 0),
+#     repeat_higher=(0, 0, total_fins - 1),
+#     center=fin_center,
+# )
 fpga = heat_sink_base + fin
 
 # entire geometry
@@ -104,6 +134,7 @@ inlet = Plane(
         channel_origin[2] + channel_dim[2],
     ),
     -1,
+    parameterization=pr,
 )
 outlet = Plane(
     (channel_origin[0] + channel_dim[0], channel_origin[1], channel_origin[2]),
@@ -113,6 +144,7 @@ outlet = Plane(
         channel_origin[2] + channel_dim[2],
     ),
     1,
+    parameterization=pr,
 )
 
 # planes for integral continuity

--- a/examples/fpga/turbulent/fpga_geometry.py
+++ b/examples/fpga/turbulent/fpga_geometry.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from sympy import Symbol, Eq, tanh
 import numpy as np
 import yaml
@@ -110,7 +111,11 @@ for i in range(total_fins):
     else:
         fin += Box(
             (fin_origin[0], fin_origin[1], fin_origin[2] + i * gap),
-            (fin_origin[0] + fin_dim[0], fin_origin[1] + fin_dim[1], fin_origin[2] + i * gap + fin_dim[2]),
+            (
+                fin_origin[0] + fin_dim[0],
+                fin_origin[1] + fin_dim[1],
+                fin_origin[2] + i * gap + fin_dim[2],
+            ),
             parameterization=pr,
         )
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Parameterized FPGA example presently fails due to the error pointed out here: https://github.com/NVIDIA/physicsnemo-sym/issues/58. While a long term fix requires an update to the `repeat` function, this workaround can unblock the FPGA example. 

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/physicsnemo-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->