### PR TITLE
Remove old getting started button

### DIFF
--- a/docs/_static/beginner_landing_buttons.html
+++ b/docs/_static/beginner_landing_buttons.html
@@ -1,14 +1,5 @@
 <!-- Icons provided from https://github.com/tabler/tabler-icons (MIT liscense)-->
 <div class="button-row">
-    <a href="./user_guide/getting_started/installation.html"><div class="botton-div">
-        <div>Install</div>
-        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-download" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-            <path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2" />
-            <polyline points="7 11 12 16 17 11" />
-            <line x1="12" y1="4" x2="12" y2="16" />
-          </svg>          
-    </div></a>
     <a href="./user_guide/basics/lid_driven_cavity_flow.html"><div class="botton-div">
         <div>Learn the Basics</div>
         <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-school" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Removes old getting started button

<img width="874" alt="image" src="https://github.com/user-attachments/assets/c170821a-d992-4ef3-bc60-2f60d2cae39b" />

Closes: https://github.com/NVIDIA/physicsnemo-sym/issues/68

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->