### PR TITLE
Update zero eq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix the zero equation formulation to correctly reflect turbulent kinematic viscosity
+
 ### Security
 
 ### Dependencies

--- a/physicsnemo/sym/eq/pdes/turbulence_zero_eq.py
+++ b/physicsnemo/sym/eq/pdes/turbulence_zero_eq.py
@@ -16,7 +16,6 @@
 
 """Zero Equation Turbulence model
 References:
-https://www.eureka.im/954.html
 https://knowledge.autodesk.com/support/cfd/learn-explore/caas/CloudHelp/cloudhelp/2019/ENU/SimCFD-Learning/files/GUID-BBA4E008-8346-465B-9FD3-D193CF108AF0-htm.html
 """
 

--- a/physicsnemo/sym/eq/pdes/turbulence_zero_eq.py
+++ b/physicsnemo/sym/eq/pdes/turbulence_zero_eq.py
@@ -113,4 +113,4 @@ class ZeroEquation(PDE):
 
         # set equations
         self.equations = {}
-        self.equations["nu"] = nu + rho * mixing_length**2 * sqrt(G)
+        self.equations["nu"] = nu + mixing_length**2 * sqrt(G)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
The present PDE included turbulent _dynamic_ viscosity. However, since the PDE describes the overall _kinematic_ viscosity, the `rho` term needs to be dropped. After that is completed, the units match. 

Other examples in PhysicsNeMo are unaffected as all of them set `rho` to `1`, so no changes are required there. 

Closes: https://github.com/NVIDIA/physicsnemo-sym/issues/118

### Math

$$ \mu_t = \rho l^2_m \sqrt{G} $$
$$ \rho = kg / m^3, l_m = m, G = 1/s^2 $$
$$ RHS = \rho l^2_m \sqrt{G} = \frac{kg}{m s} $$
$$ LHS = \mu_t = \frac{kg}{m s} $$

[Ref](https://en.wikipedia.org/wiki/Viscosity#Dynamic_viscosity)

Hence, 

$$ \nu_t = m^2 / s $$

[Ref](https://en.wikipedia.org/wiki/Viscosity#Kinematic_viscosity)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/physicsnemo-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->