### PR TITLE
Make tinycudann optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
+- Made `tiny-cuda-nn` optional in deployment image
+
 ## [2.0.0] - 2025-03-18
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_CONTAINER=physicsnemo:deploy
+ARG BASE_CONTAINER=nvcr.io/nvidia/pytorch:25.04-py3
 FROM $BASE_CONTAINER as builder
 
 ARG TARGETPLATFORM

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_CONTAINER=nvcr.io/nvidia/pytorch:25.01-py3
+ARG BASE_CONTAINER=physicsnemo:deploy
 FROM $BASE_CONTAINER as builder
 
 ARG TARGETPLATFORM
 
 # Update pip and setuptools
-RUN pip install "pip>=23.2.1" "setuptools>=70.0.0"  
+RUN pip install "pip>=23.2.1" "setuptools>=77.0.3"  
 
 # Setup git lfs, graphviz gl1(vtk dep)
 RUN apt-get update && \
@@ -51,10 +51,13 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] && [ "$VTK_ARM64_WHEEL" != "unknown
 # Install physicsnemo sym dependencies
 RUN pip install --no-cache-dir "hydra-core>=1.2.0" "termcolor>=2.1.1" "chaospy>=4.3.7" "Cython>=0.29.28" "numpy-stl>=2.16.3" "opencv-python>=4.8.1.78" \
     "scikit-learn>=1.0.2" "symengine>=0.10.0" "sympy>=1.12" "timm>=1.0.3" "torch-optimizer>=0.3.0" "transforms3d>=0.3.1" \
-    "typing>=3.7.4.3" "pillow==10.3.0" "notebook>=7.2.2" "mistune>=2.0.3" "pint>=0.19.2" "tensorboard>=2.8.0" "numpy<2.0"
+    "typing>=3.7.4.3" "notebook>=7.2.2" "mistune>=2.0.3" "pint>=0.19.2" "tensorboard>=2.8.0" "numpy<2.0"
 
 # Install warp-lang
 RUN pip install --no-cache-dir warp-lang
+
+# CI Image
+FROM builder as ci
 
 # Install tiny-cuda-nn
 ARG TCNN_CUDA_AMD64_WHEEL
@@ -74,9 +77,6 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] && [ "$TCNN_CUDA_AMD64_WHEEL" != "u
         echo "No Tiny CUDA NN wheel present, building from source" && \
 	pip install --no-cache-dir git+https://github.com/NVlabs/tiny-cuda-nn/@master#subdirectory=bindings/torch; \	
     fi
-
-# CI Image
-FROM builder as ci
 
 # Install PhysicsNeMo
 RUN if [ -e "/physicsnemo-sym/deps/physicsnemo" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ doctest:
 pytest:
 	coverage run \
 		--rcfile='test/coverage.pytest.rc' \
-		-m pytest test/
+		-m pytest --ignore-glob=*docs* --ignore=physicsnemo/sym/utils/vpinn/test_functions.py --ignore-glob=*examples*
 
 coverage:
 	coverage combine && \

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import pathlib
+from collections import defaultdict
+
+import pytest
+
+NFS_DATA_PATH = "/data/nfs/modulus-data"
+
+# Total time per file
+file_timings = defaultdict(float)
+
+
+def pytest_runtest_logreport(report):
+    if report.when == "call":
+        # report.nodeid format: path::TestClass::test_name
+        filename = report.nodeid.split("::")[0]
+        file_timings[filename] += report.duration
+
+
+def pytest_sessionfinish(session, exitstatus):
+    print("\n=== Test durations by file ===")
+    for filename, duration in sorted(
+        file_timings.items(), key=lambda x: x[1], reverse=True
+    ):
+        print(f"{filename}: {duration:.2f} seconds")
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--multigpu", action="store_true", default=False, help="run multigpu tests"
+    )
+    parser.addoption(
+        "--fail-on-missing-modules",
+        action="store_true",
+        default=False,
+        help="fail tests if required modules are missing",
+    )
+    parser.addoption(
+        "--nfs-data-dir", action="store", default=None, help="path to test data"
+    )
+
+
+@pytest.fixture(scope="session")
+def nfs_data_dir(request):
+    data_dir = pathlib.Path(
+        request.config.getoption("--nfs-data-dir")
+        or os.environ.get("TEST_DATA_DIR", NFS_DATA_PATH)
+    )
+    if not data_dir.exists():
+        pytest.skip(
+            "NFS volumes not set up with CI data repo. Run `make get-data` from the root directory of the repo"
+        )
+    print(f"Using {data_dir} as data directory")
+    return data_dir
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "multigpu: mark test as multigpu to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--multigpu") and not config.getoption("-m"):
+        skip_multigpu = pytest.mark.skip(reason="need --multigpu option to run")
+        for item in items:
+            if "multigpu" in item.keywords:
+                item.add_marker(skip_multigpu)

--- a/test/pytest_utils.py
+++ b/test/pytest_utils.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+from functools import wraps
+
+import pytest
+from packaging.version import Version
+
+
+def import_or_fail(
+    module_names: str | list[str] | tuple,
+    min_versions: str | list[str] | tuple | None = None,
+):
+    """
+    Try to import a module and skip the test if the module is not available
+    or if the version is below the minimum required version.
+
+    Args:
+        module_names (str): Name of the modules to import.
+        min_versions (str, optional): Minimum required versions of the modules.
+    """
+
+    def decorator(test_func):
+        @pytest.mark.usefixtures("pytestconfig")
+        @wraps(test_func)
+        def wrapper(*args, **kwargs):
+            pytestconfig = kwargs.get("pytestconfig")
+            if pytestconfig is None:
+                raise ValueError(
+                    "pytestconfig must be passed as an argument when using the import_or_fail_decorator."
+                )
+            _import_or_fail(module_names, pytestconfig, min_versions)
+
+            return test_func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def _import_or_fail(module_names, config, min_versions=None):
+    if not isinstance(module_names, (list, tuple)):
+        module_names = [module_names]  # allow single names
+    if min_versions is not None and not isinstance(min_versions, (list, tuple)):
+        min_versions = [min_versions]  # allow single value for min_versions
+
+    if min_versions is None:
+        min_versions = [None] * len(module_names)
+    elif len(min_versions) != len(module_names):
+        raise ValueError(
+            "The length of module_names and min_versions must be the same."
+        )
+
+    for module_name, min_version in zip(module_names, min_versions):
+        if config.getoption("--fail-on-missing-modules"):
+            __import__(module_name)
+        else:
+            try:
+                module = importlib.import_module(module_name)
+                if hasattr(module, "__version__"):
+                    if (
+                        isinstance(module.__version__, str)
+                        or module.__version__ is None
+                    ):
+                        pytest.importorskip(module_name, min_version)
+                    elif isinstance(module.__version__, Version):
+                        # pytest importorskip only works for modulues that return the version as str.
+                        version_check = Version(min_version)
+                        if module.__version__ < version_check:
+                            pytest.skip(
+                                f"{module_name} {module.__version__} is less than the required version {version_check}"
+                            )
+            except ModuleNotFoundError:
+                pytest.importorskip(module_name, min_version)

--- a/test/test_models/test_fused_mlp.py
+++ b/test/test_models/test_fused_mlp.py
@@ -14,16 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from physicsnemo.sym.models.fused_mlp import (
-    FusedMLPArch,
-    FusedFourierNetArch,
-    FusedGridEncodingNetArch,
-)
 import torch
 import numpy as np
 from physicsnemo.sym.key import Key
 
 import pytest
+from test.pytest_utils import import_or_fail
+
 
 layer_size_params = [
     pytest.param(128, id="fused_128"),
@@ -44,8 +41,15 @@ def make_dict(nr_layers):
     return _dict
 
 
+@import_or_fail("tinycudann")
 @pytest.mark.parametrize("layer_size", layer_size_params)
-def test_fully_fused_mlp(layer_size):
+def test_fully_fused_mlp(layer_size, pytestconfig):
+    from physicsnemo.sym.models.fused_mlp import (
+        FusedMLPArch,
+        FusedFourierNetArch,
+        FusedGridEncodingNetArch,
+    )
+
     batch_size = 1024
 
     data_in = np.random.random((batch_size, 2))
@@ -76,8 +80,15 @@ def test_fully_fused_mlp(layer_size):
     # assert np.allclose(data_out1, data_out2, rtol=1e-3), "Test failed!"
 
 
+@import_or_fail("tinycudann")
 @pytest.mark.parametrize("layer_size", layer_size_params)
-def test_fused_fourier_net(layer_size):
+def test_fused_fourier_net(layer_size, pytestconfig):
+    from physicsnemo.sym.models.fused_mlp import (
+        FusedMLPArch,
+        FusedFourierNetArch,
+        FusedGridEncodingNetArch,
+    )
+
     batch_size = 1024
 
     data_in = np.random.random((batch_size, 2))
@@ -109,8 +120,15 @@ def test_fused_fourier_net(layer_size):
     # assert np.allclose(data_out1, data_out2, rtol=1e-3), "Test failed!"
 
 
+@import_or_fail("tinycudann")
 @pytest.mark.parametrize("layer_size", layer_size_params)
-def test_fused_grid_encoding_net(layer_size):
+def test_fused_grid_encoding_net(layer_size, pytestconfig):
+    from physicsnemo.sym.models.fused_mlp import (
+        FusedMLPArch,
+        FusedFourierNetArch,
+        FusedGridEncodingNetArch,
+    )
+
     batch_size = 1024
 
     data_in = np.random.random((batch_size, 2))


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Make `tiny-cuda-nn` optional in Deployment Docker image. CI image will continue to have it and interested folks can build it from source following instructions from the DockerFile / [Docs](https://github.com/NVlabs/tiny-cuda-nn)

Also add `import_or_fail` mechanism from the `physicsnemo` repo to handle the tests appropriately.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->