### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/physicsnemo/sym/domain/constraint/continuous.py
+++ b/physicsnemo/sym/domain/constraint/continuous.py
@@ -133,7 +133,7 @@ class PointwiseConstraint(Constraint):
 
     def loss(self, step: int) -> Dict[str, torch.Tensor]:
         if self._output_vars is None:
-            logger.warn("Calling loss without forward call")
+            logger.warning("Calling loss without forward call")
             return {}
 
         losses = self._loss(
@@ -586,7 +586,7 @@ class IntegralConstraint(Constraint):
 
     def loss(self, step: int) -> Dict[str, torch.Tensor]:
         if self._output_vars is None:
-            logger.warn("Calling loss without forward call")
+            logger.warning("Calling loss without forward call")
             return {}
 
         # split for individual integration

--- a/physicsnemo/sym/domain/constraint/discrete.py
+++ b/physicsnemo/sym/domain/constraint/discrete.py
@@ -161,7 +161,7 @@ class SupervisedGridConstraint(Constraint):
 
     def loss(self, step: int) -> Dict[str, torch.Tensor]:
         if self._output_vars is None:
-            logger.warn("Calling loss without forward call")
+            logger.warning("Calling loss without forward call")
             return {}
 
         losses = self._loss(

--- a/physicsnemo/sym/domain/inferencer/ov.py
+++ b/physicsnemo/sym/domain/inferencer/ov.py
@@ -188,7 +188,7 @@ class OVVoxelInferencer(Inferencer):
         # If mask set up mask indexes
         if mask_fn is not None:
             args = _get_function_argspec(mask_fn)["args"]
-            # Fall back np_lambdify does not supply arguement names
+            # Fall back np_lambdify does not supply argument names
             # Ideally np_lambdify should allow input names to be queried
             if len(args) == 0:
                 args = list(invar.keys())  # Hope your inputs all go into the mask
@@ -304,7 +304,7 @@ class OVVoxelInferencer(Inferencer):
         return invar, predvar
 
     def save_results(self, name, results_dir, writer, save_filetypes, step):
-        logger.warn(
+        logger.warning(
             "OVoxInferencer is not designed to be used inside of PhysicsNeMo solver"
         )
         pass
@@ -465,7 +465,7 @@ class OVFourCastNetInferencer(Inferencer):
         """
         torch.cuda.set_per_process_memory_fraction(memory_fraction)
 
-        # Create ouput prediction tensor [Tsteps, C, H, W]
+        # Create output prediction tensor [Tsteps, C, H, W]
         shape = self.init_state.shape
         outputs = torch.zeros(shape[0] + tsteps, shape[1], shape[2], shape[3])
         outputs[0] = (self.init_state - self.mu) / self.std
@@ -532,7 +532,7 @@ class OVFourCastNetInferencer(Inferencer):
         return np.load(array_file)
 
     def save_results(self, name, results_dir, writer, save_filetypes, step):
-        logger.warn(
+        logger.warning(
             "OVFourCastNetInferencer is not designed to be used inside of PhysicsNeMo solver"
         )
         pass

--- a/physicsnemo/sym/hydra/config.py
+++ b/physicsnemo/sym/hydra/config.py
@@ -149,7 +149,7 @@ class ExperimentalPhysicsNeMoConfig(PhysicsNeMoConfig):
 def register_physicsnemo_configs() -> None:
 
     if not torch.__version__ == JIT_PYTORCH_VERSION:
-        logger.warn(
+        logger.warning(
             f"TorchScript default is being turned off due to PyTorch version mismatch."
         )
 

--- a/physicsnemo/sym/hydra/utils.py
+++ b/physicsnemo/sym/hydra/utils.py
@@ -276,7 +276,7 @@ def instantiate_sched(
                 "gamma": sched_cfg.decay_rate ** (1.0 / sched_cfg.decay_steps),
             }
         else:
-            logger.warn("Detected unsupported custom scheduler", sched_cfg)
+            logger.warning("Detected unsupported custom scheduler", sched_cfg)
 
     try:
         scheduler = hydra.utils.instantiate(sched_cfg, optimizer=optimizer)

--- a/physicsnemo/sym/trainer.py
+++ b/physicsnemo/sym/trainer.py
@@ -519,7 +519,7 @@ class Trainer(AdamMixin, AdaHessianMixin, BFGSMixin):
         if self.cfg.jit:
             # Warn user if pytorch version difference
             if not torch.__version__ == JIT_PYTORCH_VERSION:
-                self.log.warn(
+                self.log.warning(
                     f"Installed PyTorch version {torch.__version__} is not TorchScript"
                     + f" supported in PhysicsNeMo. Version {JIT_PYTORCH_VERSION} is officially supported."
                 )
@@ -667,7 +667,7 @@ class Trainer(AdamMixin, AdaHessianMixin, BFGSMixin):
                 # check for infs/NaNs in loss
                 if not torch.isfinite(loss):
                     if self.amp_manager.enabled:
-                        self.log.warn(f"{self.step_str} loss went to INFs/NaNs")
+                        self.log.warning(f"{self.step_str} loss went to INFs/NaNs")
                     else:
                         self.log.error(f"{self.step_str} loss went to INFs/NaNs")
                         break
@@ -869,7 +869,7 @@ class Trainer(AdamMixin, AdaHessianMixin, BFGSMixin):
                 dist.barrier(device_ids=[self.manager.local_rank])
 
             if self.cfg.cuda_graph_warmup < 11:
-                self.log.warn(
+                self.log.warning(
                     f"Graph warm up length ({self.cfg.cuda_graph_warmup}) should be more than 11 steps, higher suggested"
                 )
             self.log.info("Attempting cuda graph building, this may take a bit...")

--- a/physicsnemo/sym/utils/io/vtk.py
+++ b/physicsnemo/sym/utils/io/vtk.py
@@ -69,7 +69,7 @@ class VTKBase:
 
     def get_array(self, name: str, dim: Union[None, int] = None):
         if name not in self.get_array_names():
-            logger.warn(f"{name} not found in data arrays")
+            logger.warning(f"{name} not found in data arrays")
             return None
 
         data_array = vtk_to_numpy(self.vtk_obj.GetPointData().GetArray(name))
@@ -148,7 +148,7 @@ class VTKBase:
                         np.zeros((self.vtk_obj.GetNumberOfPoints(), 1), dtype=np.short)
                     )
 
-            # If we recieved any data that fits the map
+            # If we received any data that fits the map
             if len(vtk_array) > 0:
                 out_var[key] = np.squeeze(np.concatenate(vtk_array, axis=1))
 
@@ -210,7 +210,7 @@ class VTKBase:
         if name in self.get_array_names():
             self.vtk_obj.GetPointData().RemoveArray(name)
         else:
-            logger.warn(f"Point data {name} not present in VTK object")
+            logger.warning(f"Point data {name} not present in VTK object")
 
 
 class VTKUniformGrid(VTKBase):
@@ -507,7 +507,7 @@ class VTKUnstructuredGrid(VTKBase):
     cell_index : Tuple[ np.array, np.array ]
         Tuple of (cell_offsets, cell_connectivity) arrays.
         Cell offsets is a 1D array denoting how many points make up a face for each cell.
-        Cell connectivity is a 1D array that contains verticies of each cell face in order
+        Cell connectivity is a 1D array that contains vertices of each cell face in order
     cell_types : np.array
         Array of cell vtk types:
         https://vtk.org/doc/nightly/html/vtkCellType_8h_source.html
@@ -592,7 +592,7 @@ class VTKUnstructuredGrid(VTKBase):
     def get_cells(self):
         cells = self.vtk_obj.GetCells()
         # Get cells data contains array [nedges, v1, v2, v3, ..., nedges, v1, v2, v3,...]
-        # Need to seperate offset and connectivity array for practical use
+        # Need to separate offset and connectivity array for practical use
         cell_connectivity = vtk_to_numpy(cells.GetConnectivityArray())
         cell_offsets = vtk_to_numpy(cells.GetOffsetsArray())
         return cell_offsets, cell_connectivity
@@ -672,7 +672,7 @@ class VTKPolyData(VTKBase):
     poly_index : Tuple[poly_offsets, poly_connectivity]
         Tuple of polygon offsets and polygon connectivity arrays.
         Polygon offsets is a 1D array denoting how many points make up a face for each polygon.
-        Polygon connectivity is a 1D array that contains verticies of each polygon face in order, by default None
+        Polygon connectivity is a 1D array that contains vertices of each polygon face in order, by default None
     export_map : Dict[str, List[str]], optional
         Export map dictionary with keys that are VTK variables names and values that are lists of output variables. Will use 1 to 1 mapping if none is provided, by default {}
     file_name : str, optional
@@ -747,7 +747,7 @@ class VTKPolyData(VTKBase):
     def get_polys(self):
         polys = self.vtk_obj.GetPolys()
         # Poly data contains array [nedges, v1, v2, v3, ..., nedges, v1, v2, v3,...]
-        # Need to seperate offset and connectivity array for practical use
+        # Need to separate offset and connectivity array for practical use
         poly_connectivity = vtk_to_numpy(polys.GetConnectivityArray())
         poly_offsets = vtk_to_numpy(polys.GetOffsetsArray())
         return poly_offsets, poly_connectivity
@@ -860,14 +860,14 @@ class VTKFromFile(object):
                 vtk_reader = cls.readXMLVTK(file_path)
                 read_success = True
             except:
-                logger.warn("VTK file not valid XML format, will attempt legacy load")
+                logger.warning("VTK file not valid XML format, will attempt legacy load")
         # If failed or legacy force, create VTK Reader
         if not read_success:
             try:
                 vtk_reader = cls.readLegacyVTK(file_path)
                 read_success = True
             except:
-                logger.warn("VTK file not valid VTK format")
+                logger.warning("VTK file not valid VTK format")
         # Hopefully VTK reader is loaded
         assert read_success, "Failed to load VTK file in either XML or Legacy format"
         logger.info(f"Read {Path(file_path).name} file successfully")
@@ -937,7 +937,7 @@ class VTKFromFile(object):
 def var_to_polyvtk(
     var_dict: Dict[str, np.array], file_path: str, coordinates=["x", "y", "z"]
 ):
-    """Helper method for nodes to export thier variables to a vtkPolyData file
+    """Helper method for nodes to export their variables to a vtkPolyData file
     Should be avoided when possible as other VTK formats can save on memory.
 
     Parameters


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
This small PR resolves those warnings.


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->