### PR TITLE
Typos in Linear Elasticity PDE docstring

### DIFF
--- a/physicsnemo/sym/eq/pdes/linear_elasticity.py
+++ b/physicsnemo/sym/eq/pdes/linear_elasticity.py
@@ -31,13 +31,13 @@ class LinearElasticity(PDE):
     Parameters
     ==========
     E : float, Sympy Symbol/Expr, str
-        The Young's physicsnemo
+        The Young's modulus
     nu : float, Sympy Symbol/Expr, str
         The Poisson's ratio
     lambda_: float, Sympy Symbol/Expr, str
         Lamé's first parameter
     mu: float, Sympy Symbol/Expr, str
-        Lamé's second parameter (shear physicsnemo)
+        Lamé's second parameter (shear modulus)
     rho: float, Sympy Symbol/Expr, str
         Mass density.
     dim : int

--- a/physicsnemo/sym/eq/pdes/linear_elasticity.py
+++ b/physicsnemo/sym/eq/pdes/linear_elasticity.py
@@ -208,13 +208,13 @@ class LinearElasticityPlaneStress(PDE):
     Parameters
     ==========
     E : float, Sympy Symbol/Expr, str
-        The Young's physicsnemo
+        The Young's modulus
     nu : float, Sympy Symbol/Expr, str
         The Poisson's ratio
     lambda_: float, Sympy Symbol/Expr, str
         Lamé's first parameter.
     mu: float, Sympy Symbol/Expr, str
-        Lamé's second parameter (shear physicsnemo)
+        Lamé's second parameter (shear modulus)
     rho: float, Sympy Symbol/Expr, str
         Mass density.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description

Fixed 4 typos in Linear Elasticity PDEs docstrings.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->