### PR TITLE
Hot fixes for release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_CONTAINER=nvcr.io/nvidia/pytorch:25.04-py3
+ARG BASE_CONTAINER=nvcr.io/nvidia/pytorch:25.06-py3
 FROM $BASE_CONTAINER as builder
 
 ARG TARGETPLATFORM

--- a/physicsnemo/sym/__init__.py
+++ b/physicsnemo/sym/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.2.0a0"
+__version__ = "2.2.0"
 
 from pint import UnitRegistry
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools", "setuptools-scm<9.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Setuptools SCM has introduced some major changes that are breaking the builds. This temporarily upper bounds the setuptools-scm version which makes the builds pass. Once the stable release is available, we can remove this upper bound.

As of Aug 11, lot of releases of setuptools-scm are being yanked: https://setuptools-scm.readthedocs.io/en/latest/changelog/

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->