### PR TITLE
Remove deprecated CUDA architecture flag for nvcc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ from torch.utils.cpp_extension import CUDAExtension, BuildExtension
 def cuda_extension():
     cuda_version = float(torch.version.cuda)
     nvcc_args = [
-        "-gencode=arch=compute_70,code=sm_70",
         "-gencode=arch=compute_75,code=sm_75",
     ]
     if cuda_version >= 11:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
Remove the support for V100. 

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->