### PR TITLE
Fix failing Johns Hopkins Turbulence DB calls by upgrading pyJHTDB to giverny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed HTTP Error 308 when running `examples/super_resolution.py`
+
 ### Security
 
 ### Dependencies

--- a/docs/user_guide/intermediate/turbulence_super_resolution.rst
+++ b/docs/user_guide/intermediate/turbulence_super_resolution.rst
@@ -27,8 +27,8 @@ In this example you will learn the following:
 
 .. warning::
 
-   The Python package `pyJHTDB <https://github.com/idies/pyJHTDB>`_ is required for this example to download and process the training and validation datasets.
-   Install using ``pip install pyJHTDB``.
+   The Python package `giverny <https://github.com/sciserver/giverny>`_ is required for this example to download and process the training and validation datasets.
+   Install using ``pip install giverny``.
 
 Problem Description
 -------------------

--- a/examples/super_resolution/conf/config.yaml
+++ b/examples/super_resolution/conf/config.yaml
@@ -59,7 +59,7 @@ custom:
     n_train: 512
     n_valid: 16
     domain_size: 128
-    access_token: "edu.jhu.pha.turbulence.testing-201311" #Replace with your own token here
+    access_token: "edu.jhu.pha.turbulence.testing-201406" #Replace with your own token here
 
   loss_weights:
     U: 1.0


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Hi team!

I am a PhD student with the Johns Hopkins Turbulence Database team, whose data you use for your Turbulence Superresolution example (`examples/super_resolution.py`).

Due to our backend changes, API calls using the deprecated `pyJHTDB` library which your code is using return Error 308. Dataset download fails, and so does the whole pipeline. I did not find an existing Issue on this, so I created one [271](https://github.com/NVIDIA/physicsnemo-sym/issues/271)

We discussed this issue with Mike O'Keefe (mokeeffe@nvidia.com) and Jeffrey Lancaster (jlancaster@nvidia.com) and I, on behalf of the JHTDB team, came up with this solution.

This PR provides the upgrade to the new library, called `givernylocal`. The code is equivalent to the original pyJHTDB method

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [X] An [issue](https://github.com/NVIDIA/physicsnemo-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
New dependency: [givernylocal](github.com/sciserver/giverny)
Removed dependency: [pyJHTDB](https://github.com/idies/pyJHTDB/tree/master/pyJHTDB)