### PR TITLE
Remove numpoly dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "mistune>=2.0",
     "ninja",
     "notebook>=7.2.2",
-    "numpoly<=1.3.4",
     "numpy-stl>=2.16",
     "nvidia-physicsnemo>=2.0.0",
     "opencv-python>=4.8.1.78",


### PR DESCRIPTION
Removed 'numpoly' dependency from the project.

<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->